### PR TITLE
Handle weird legacy GCN Circular URLs

### DIFF
--- a/src/replacements/gcn-circular/index.ts
+++ b/src/replacements/gcn-circular/index.ts
@@ -11,7 +11,7 @@ const circularIdRegExp = /\d+(?:a|\.5)?/gi
 const circularId = circularIdRegExp.source
 const legacyUrlOrigin = /https?:\/\/gcn\.gsfc\.nasa\.gov/.source
 const legacyUrlExtension = /\.gcn3/.source
-const legacyUrl = `${legacyUrlOrigin}/gcn3/(${circularId})${legacyUrlExtension}`
+const legacyUrl = `${legacyUrlOrigin}/(?:gcn/)*gcn3/(${circularId})${legacyUrlExtension}`
 const urlOrigin = /https?:\/\/gcn.nasa.gov/.source
 const url = `${urlOrigin}/circulars/(${circularId})`
 

--- a/src/replacements/gcn-circular/test.html
+++ b/src/replacements/gcn-circular/test.html
@@ -2,5 +2,6 @@
 <p>This paragraph refers to GCN Circular <data class="gcn-circular" value="123">123</data> and GCN <data class="gcn-circular" value="456">456</data></p>
 <p>You can refer to a Circular by its URL: <data class="gcn-circular" value="26640">https://gcn.nasa.gov/circulars/26640</data></p>
 <p>A legacy URL works too: <data class="gcn-circular" value="26640">https://gcn.gsfc.nasa.gov/gcn3/26640.gcn3</data></p>
+<p>And even really weird legacy URLs work: <data class="gcn-circular" value="33567">https://gcn.gsfc.nasa.gov/gcn/gcn/gcn/gcn3/33567.gcn3</data></p>
 <p>GCN Circ. <data class="gcn-circular" value="789">789</data> and GCN Circs. <data class="gcn-circular" value="3">3</data> and <data class="gcn-circular" value="4">4</data></p>
 <p>And this one refers to GCNs <data class="gcn-circular" value="1">1</data>, <data class="gcn-circular" value="23.5">23a</data>, <data class="gcn-circular" value="45.5">45.5</data> and <data class="gcn-circular" value="42">42</data></p>

--- a/src/replacements/gcn-circular/test.json
+++ b/src/replacements/gcn-circular/test.json
@@ -87,6 +87,23 @@
       "children": [
         {
           "type": "text",
+          "value": "And even really weird legacy URLs work: "
+        },
+        {
+          "type": "text",
+          "value": "https://gcn.gsfc.nasa.gov/gcn/gcn/gcn/gcn3/33567.gcn3",
+          "data": {
+            "class": "gcn-circular",
+            "value": 33567
+          }
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
           "value": "GCN Circ. "
         },
         {

--- a/src/replacements/gcn-circular/test.md
+++ b/src/replacements/gcn-circular/test.md
@@ -6,6 +6,8 @@ You can refer to a Circular by its URL: https://gcn.nasa.gov/circulars/26640
 
 A legacy URL works too: https://gcn.gsfc.nasa.gov/gcn3/26640.gcn3
 
+And even really weird legacy URLs work: https://gcn.gsfc.nasa.gov/gcn/gcn/gcn/gcn3/33567.gcn3
+
 GCN Circ. 789 and GCN Circs. 3 and 4
 
 And this one refers to GCNs 1, 23a, 45.5 and 42


### PR DESCRIPTION
Apparently https://gcn.gsfc.nasa.gov/gcn/gcn/gcn/gcn3/33567.gcn3 is a valid URL.