### PR TITLE
Match DOIs with multiple slashes

### DIFF
--- a/src/replacements/doi/index.ts
+++ b/src/replacements/doi/index.ts
@@ -2,7 +2,7 @@ import type { FindAndReplace } from '../index.js'
 
 const doiMarker = /(?:doi:|https?:\/\/(?:dx\.)?doi\.org\/)/.source
 const suffixChars = /[a-zA-Z0-9]/.source
-const suffixCharsNonTerminal = /[-_.~%]/.source
+const suffixCharsNonTerminal = /[-_.~%/]/.source
 const prefix = /10\.\d{4,}/.source
 const terminal = /\s|$/.source
 

--- a/src/replacements/doi/test.html
+++ b/src/replacements/doi/test.html
@@ -2,3 +2,4 @@
 <p>Cite <data class="doi" value="10.1000/foo.bar">doi:10.1000/foo.bar</data>, cite <data class="doi" value="10.1000/bat.baz">doi:10.1000/bat.baz</data>. Another sentence.</p>
 <p>You can use DOI URls like <data class="doi" value="10.1000/foo.bar">http://dx.doi.org/10.1000/foo.bar</data> or <data class="doi" value="10.1000/foo.bar">https://doi.org/10.1000/foo.bar</data></p>
 <p>Cite <data class="doi" value="10.1000/foo.bar">doi:10.1000/foo.bar</data>.</p>
+<p>Cite <data class="doi" value="10.1000/foo.bar/bat">doi:10.1000/foo.bar/bat</data>, <data class="doi" value="10.1000/foo.bar/baf/baz">doi:10.1000/foo.bar/baf/baz</data>.</p>

--- a/src/replacements/doi/test.json
+++ b/src/replacements/doi/test.json
@@ -104,6 +104,39 @@
           "value": "."
         }
       ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Cite "
+        },
+        {
+          "type": "text",
+          "value": "doi:10.1000/foo.bar/bat",
+          "data": {
+            "class": "doi",
+            "value": "10.1000/foo.bar/bat"
+          }
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "doi:10.1000/foo.bar/baf/baz",
+          "data": {
+            "class": "doi",
+            "value": "10.1000/foo.bar/baf/baz"
+          }
+        },
+        {
+          "type": "text",
+          "value": "."
+        }
+      ]
     }
   ]
 }

--- a/src/replacements/doi/test.md
+++ b/src/replacements/doi/test.md
@@ -5,3 +5,5 @@ Cite doi:10.1000/foo.bar, cite doi:10.1000/bat.baz. Another sentence.
 You can use DOI URls like http://dx.doi.org/10.1000/foo.bar or https://doi.org/10.1000/foo.bar
 
 Cite doi:10.1000/foo.bar.
+
+Cite doi:10.1000/foo.bar/bat, doi:10.1000/foo.bar/baf/baz.


### PR DESCRIPTION
We assumed that DOI suffixes could only have a single slash, but they can have more than one slash. For example, in the DOI `10.1093/mnras/stz2357`, the prefix is `10.1093` and the suffix is `mnras/stz2357`.