### PR TITLE
Bump TypeScript version, fixes segfaults on Node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,12 +36,12 @@
         "remark-parse": "^10.0.2",
         "remark-rehype": "^10.1.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.2.2",
+        "typescript": "^5.4.5",
         "unified": "^10.0.0",
         "unist-util-remove-position": "^5.0.0"
       },
       "engines": {
-        "node": ">=18 <22"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9943,9 +9943,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
     "remark-parse": "^10.0.2",
     "remark-rehype": "^10.1.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.5",
     "unified": "^10.0.0",
     "unist-util-remove-position": "^5.0.0"
   },
   "engines": {
-    "node": ">=18 <22"
+    "node": ">=18"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
I spent a lot of time trying to come up with a minimal reproducer for the segfaults under Node 22, but ultimately found that the segfault was fixed by simply upgrading TypeScript.