### PR TITLE
Correct links to GCN repository files in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ You can enrich these [`<data>`](https://developer.mozilla.org/en-US/docs/Learn/H
 
 For an example of Astro Flavored Markdown enriched with React components, see the following files:
 
-- https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId/Body.tsx
+- https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId.(%24version)/Body.tsx
 - https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId/AstroData.tsx
 - https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId/AstroData.components.tsx

--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ You can enrich these [`<data>`](https://developer.mozilla.org/en-US/docs/Learn/H
 For an example of Astro Flavored Markdown enriched with React components, see the following files:
 
 - https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId.(%24version)/Body.tsx
-- https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId/AstroData.tsx
-- https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId/AstroData.components.tsx
+- https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId.(%24version)/AstroData.tsx
+- https://github.com/nasa-gcn/gcn.nasa.gov/blob/main/app/routes/circulars.%24circularId.(%24version)/AstroData.components.tsx


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
The links to relevant files in the GCN repository were from an outdated directory structure, resulting in the links being broken. These links are updated to point to the intended files as of June 2024.

It may be advisable to pin the links to a specific commit to ensure they don't break in the future if the structure of the GCN repository changes again

# Related Issue(s)
Resolves #41 

# Testing
1. Navigate to GCN links at the bottom of the README.md file to ensure they link to the proper files.
