### PR TITLE
Correctly parse DOIs with colons in them

### DIFF
--- a/src/replacements/doi/index.ts
+++ b/src/replacements/doi/index.ts
@@ -2,7 +2,7 @@ import type { FindAndReplace } from '../index.js'
 
 const doiMarker = /(?:doi:|https?:\/\/(?:dx\.)?doi\.org\/)/.source
 const suffixChars = /[a-zA-Z0-9]/.source
-const suffixCharsNonTerminal = /[-_.~%/]/.source
+const suffixCharsNonTerminal = /[:-_.~%/]/.source
 const prefix = /10\.\d{4,}/.source
 const terminal = /\s|$/.source
 

--- a/src/replacements/doi/test.html
+++ b/src/replacements/doi/test.html
@@ -1,5 +1,5 @@
 <p>Citing <data class="doi" value="10.1000/foo.bar">doi:10.1000/foo.bar</data> in a sentence.</p>
 <p>Cite <data class="doi" value="10.1000/foo.bar">doi:10.1000/foo.bar</data>, cite <data class="doi" value="10.1000/bat.baz">doi:10.1000/bat.baz</data>. Another sentence.</p>
-<p>You can use DOI URls like <data class="doi" value="10.1000/foo.bar">http://dx.doi.org/10.1000/foo.bar</data> or <data class="doi" value="10.1000/foo.bar">https://doi.org/10.1000/foo.bar</data></p>
+<p>You can use DOI URls like <data class="doi" value="10.1000/foo.bar">http://dx.doi.org/10.1000/foo.bar</data> or <data class="doi" value="10.1000/foo.bar">https://doi.org/10.1000/foo.bar</data> or <data class="doi" value="10.1051/aas:2000214">https://doi.org/10.1051/aas:2000214</data></p>
 <p>Cite <data class="doi" value="10.1000/foo.bar">doi:10.1000/foo.bar</data>.</p>
 <p>Cite <data class="doi" value="10.1000/foo.bar/bat">doi:10.1000/foo.bar/bat</data>, <data class="doi" value="10.1000/foo.bar/baf/baz">doi:10.1000/foo.bar/baf/baz</data>.</p>

--- a/src/replacements/doi/test.json
+++ b/src/replacements/doi/test.json
@@ -81,6 +81,18 @@
             "class": "doi",
             "value": "10.1000/foo.bar"
           }
+        },
+        {
+          "type": "text",
+          "value": " or "
+        },
+        {
+          "type": "text",
+          "value": "https://doi.org/10.1051/aas:2000214",
+          "data": {
+            "class": "doi",
+            "value": "10.1051/aas:2000214"
+          }
         }
       ]
     },

--- a/src/replacements/doi/test.md
+++ b/src/replacements/doi/test.md
@@ -2,7 +2,7 @@ Citing doi:10.1000/foo.bar in a sentence.
 
 Cite doi:10.1000/foo.bar, cite doi:10.1000/bat.baz. Another sentence.
 
-You can use DOI URls like http://dx.doi.org/10.1000/foo.bar or https://doi.org/10.1000/foo.bar
+You can use DOI URls like http://dx.doi.org/10.1000/foo.bar or https://doi.org/10.1000/foo.bar or https://doi.org/10.1051/aas:2000214
 
 Cite doi:10.1000/foo.bar.
 


### PR DESCRIPTION
Correclty parse `https://doi.org/10.1051/aas:2000214` as `10.1051/aas:2000214`, not `10.1051/aas`.

Fixes https://github.com/nasa-gcn/gcn.nasa.gov/issues/2998.