### PR TITLE
Fix overly permissive regular expression

### DIFF
--- a/src/replacements/doi/index.ts
+++ b/src/replacements/doi/index.ts
@@ -2,7 +2,7 @@ import type { FindAndReplace } from '../index.js'
 
 const doiMarker = /(?:doi:|https?:\/\/(?:dx\.)?doi\.org\/)/.source
 const suffixChars = /[a-zA-Z0-9]/.source
-const suffixCharsNonTerminal = /[:-_.~%/]/.source
+const suffixCharsNonTerminal = /[-:_.~%/]/.source
 const prefix = /10\.\d{4,}/.source
 const terminal = /\s|$/.source
 


### PR DESCRIPTION
This regular expression capture should include a literal hyphen, not a range of characters.

Fixes #166.